### PR TITLE
Split quota-policy definition. Allow comments.

### DIFF
--- a/draft-polli-ratelimit-headers.md
+++ b/draft-polli-ratelimit-headers.md
@@ -964,11 +964,19 @@ Here are some interoperability issues:
 
 10. Is the quota-policy definition {{quota-policy}} too complex?
 
-    The only runtime value that should be usable is the first element of the list,
-    so for the following header:
+    The key runtime value is the first element of the list, the others are informative.
+    So for the following header:
 
     ```
     RateLimit-Limit: 100, 100; window=60;burst=1000;comment="sliding window", 5000;window=3600;burst=0;comment="fixed window"
     ```
 
-    the actual value referencing the lowest limit is `100`
+    the key value is the one referencing the lowest limit: `100`
+    You can always return the simplest form of the 3 headers
+
+    ```
+    RateLimit-Limit: 100
+    RateLimit-Remaining: 50
+    RateLimit-Reset: 60
+    ```
+

--- a/draft-polli-ratelimit-headers.md
+++ b/draft-polli-ratelimit-headers.md
@@ -253,7 +253,7 @@ GET /books?author=Eco           ; request-quota=4, remaining: 0, status=429
 
 ## Quota policy {#quota-policy}
 
-A quota policy is described in the following format
+This specification allows describing a quota policy with the following syntax:
 
     quota-policy = request-quota; "window" "=" time-window *( OWS ";" OWS quota-comment)
     quota-comment = token "=" (token / quoted-string)


### PR DESCRIPTION
## This PR

- splits quota policy definition from RateLimit-Limit
- allows custom parameters in quota-policy, like 'burst', 'policy' or 'comment'
- introduces the concept of 'quota-unit' to nicely replace 'request'

