### PR TITLE
Relax the relationship of RateLimit headers with Retry-After and add examples

### DIFF
--- a/draft-polli-ratelimit-headers.md
+++ b/draft-polli-ratelimit-headers.md
@@ -629,7 +629,7 @@ Ratelimit-Reset: 50
 The policy conveyed by `RateLimit-Limit` states that
 the server accepts 100 quota-units per minute.
 
-Due to resource scarcity, the server artificially lowers
+To avoid resource exhaustion, the server artificially lowers
 the actual limits returned in the throttling headers.
 
 The current policy then advertises

--- a/draft-polli-ratelimit-headers.md
+++ b/draft-polli-ratelimit-headers.md
@@ -632,7 +632,7 @@ the server accepts 100 quota-units per minute.
 To avoid resource exhaustion, the server artificially lowers
 the actual limits returned in the throttling headers.
 
-The current policy then advertises
+The  `RateLimit-Remaining` then advertises
 only 9 quota-units for the next 50 seconds to slow down the client.
 
 Note that the server could have lowered even the other

--- a/draft-polli-ratelimit-headers.md
+++ b/draft-polli-ratelimit-headers.md
@@ -656,7 +656,10 @@ RateLimit-Limit: 10, 100;w=60
 Ratelimit-Remaining: 9
 Ratelimit-Reset: 50
 
-{"hello": "world"}
+{
+  "status": 200,
+  "detail": "Just slow down without waiting."
+}
 ~~~
 
 ### Dynamic limits for pushing back and slowing down
@@ -679,10 +682,15 @@ Response:
 
 ~~~
 HTTP/1.1 429 Too Many Requests
+Content-Type: application/json
 RateLimit-Limit: 0, 15;w=20
 Ratelimit-Remaining: 0
 Ratelimit-Reset: 20
 
+{
+  "status": 429,
+  "detail": "Wait 20 seconds, then slow down!"
+}
 ~~~
 
 ## Dynamic limits for pushing back with Retry-After and slow down
@@ -706,11 +714,16 @@ Response:
 
 ~~~
 HTTP/1.1 429 Too Many Requests
+Content-Type: application/json
 Retry-After: 20
 RateLimit-Limit: 15, 100;w=60
 Ratelimit-Remaining: 15
 Ratelimit-Reset: 40
 
+{
+  "status": 429,
+  "detail": "Wait 20 seconds, then slow down!"
+}
 ~~~
 
 Note that in this last response the client is expected to honor the

--- a/draft-polli-ratelimit-headers.md
+++ b/draft-polli-ratelimit-headers.md
@@ -1052,7 +1052,7 @@ At this point you should stop increasing your request rate.
    Service Level Objectives not meet, ..).
 
    Availability can be improved by dynamically lowering the values returned by
-   the rate-limit headers to slow down clients, and retry-after can be used to
+   the `RateLimit-*` headers to slow down clients, and `Retry-After` can be used to
    push them back.
 
    Saturation conditions can be either dynamic or static: all this is out of

--- a/draft-polli-ratelimit-headers.md
+++ b/draft-polli-ratelimit-headers.md
@@ -665,7 +665,7 @@ Continuing the previous example, let's say the client waits 10 seconds and
 performs a new request which, due to resource exhaustion, the server rejects
 and pushes back, advertising `RateLimit-Remaining: 0` for the next 20 seconds.
 
-The server decides to advertise a new smaller window with a lower limit to slow
+The server advertises a smaller window with a lower limit to slow
 down the client for the rest of its original window after the 20 seconds elapse.
 
 Request:

--- a/draft-polli-ratelimit-headers.md
+++ b/draft-polli-ratelimit-headers.md
@@ -567,7 +567,7 @@ RateLimit-Reset: 56
 A client exhausted its quota and the server throttles the request
 sending the `Retry-After` response header field.
 
-The values of `Retry-After` and `RateLimit-Reset` reference the same moment,
+In this example, the values of `Retry-After` and `RateLimit-Reset` reference the same moment,
 but this is not a requirement.
 
 The `429 Too Many Requests` HTTP status code is just used as an example.

--- a/draft-polli-ratelimit-headers.md
+++ b/draft-polli-ratelimit-headers.md
@@ -568,7 +568,7 @@ A client exhausted its quota and the server throttles the request
 sending the `Retry-After` response header field.
 
 The values of `Retry-After` and `RateLimit-Reset` reference the same moment,
-but there is no requirement that they do so.
+but this is not a requirement.
 
 The `429 Too Many Requests` HTTP status code is just used as an example.
 

--- a/draft-polli-ratelimit-headers.md
+++ b/draft-polli-ratelimit-headers.md
@@ -398,7 +398,8 @@ A server MAY return `RateLimit` response header fields independently
 of the response status code.  This includes throttled responses.
 
 If a response contains both the `Retry-After` and the `RateLimit-Reset` header fields,
-the value of `RateLimit-Reset` MUST be consistent with the one of `Retry-After`.
+the value of `RateLimit-Reset` MAY reference the same point in time as
+`Retry-After`.
 
 When using a policy involving more than one `time-window`,
 the server MUST reply with the `RateLimit` headers related to the window
@@ -566,8 +567,8 @@ RateLimit-Reset: 56
 A client exhausted its quota and the server throttles the request
 sending the `Retry-After` response header field.
 
-The values of `Retry-After` and `RateLimit-Reset` are consistent as they
-reference the same moment.
+The values of `Retry-After` and `RateLimit-Reset` reference the same moment,
+but there is no requirement that they do so.
 
 The `429 Too Many Requests` HTTP status code is just used as an example.
 

--- a/draft-polli-ratelimit-headers.md
+++ b/draft-polli-ratelimit-headers.md
@@ -398,7 +398,7 @@ A server MAY return `RateLimit` response header fields independently
 of the response status code.  This includes throttled responses.
 
 If a response contains both the `Retry-After` and the `RateLimit-Reset` header fields,
-the value of `RateLimit-Reset` MAY reference the same point in time as
+the value of `RateLimit-Reset` SHOULD reference the same point in time as
 `Retry-After`.
 
 When using a policy involving more than one `time-window`,

--- a/draft-polli-ratelimit-headers.md
+++ b/draft-polli-ratelimit-headers.md
@@ -991,8 +991,9 @@ At this point you should stop increasing your request rate.
    in case of resource saturation (eg. thrashing, connection queues too long,
    Service Level Objectives not meet, ..).
 
-   Dynamically lowering the values returned by the rate-limit headers,
-   and returning retry-after along with them can improve availability.
+   Availability can be improved by dynamically lowering the values returned by
+   the rate-limit headers to slow down clients, and retry-after can be used to
+   push them back.
 
    Saturation conditions can be either dynamic or static: all this is out of
    the scope for the current document.


### PR DESCRIPTION
This is very much an open discussion at this point, following up on #3.

Feel free to comment on how these should work, and suggest additional examples or changes in the ones I have used.